### PR TITLE
Improve README and fix minor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,83 @@
 # SDUOJ-SANDBOX
 
-This is the sandbox of judger for SDUOJ, which provides a secure environment for running user's code that is submitted from web.
+This project provides the sandbox used by SDU Online Judge. It creates a restricted environment for running user submitted programs using `setrlimit` and `seccomp`.
 
-The sandbox can run on `Linux` with system call `setrlimit` and `seccomp` to limit the resource and some dangerous system calls.
+## Install
 
-# Install
+The sandbox depends on `libseccomp-dev`.
 
-Building this sandbox need `libseccomp-dev`, you can install it with command followed.
-
-```
-$ sudo apt-get install libseccomp-dev
+```bash
+sudo apt-get install libseccomp-dev
 ```
 
-Then, you can install the sandbox to `/opt/sduoj-sandbox/bin/sandbox` and `/usr/bin/sandbox`
+Compile and install to `/opt/sduoj-sandbox/bin/sandbox` and `/usr/bin/sandbox`:
 
-```
-$ make
-$ sudo make install
-```
-
-If you want to uninstall it, you can run 
-
-```
-$ sudo make uninstall
+```bash
+make
+sudo make install
 ```
 
-# Usage
+Uninstall with:
+
+```bash
+sudo make uninstall
+```
+
+## Usage
 
 ### Example
 
-You can run the sandbox with such command
-
-```
+```bash
 # root privilege is needed
-$ sudo ./sandbox \
-    --exe_path="/usr/bin/python3" \     # executable file path
-    --exe_args="test/test_py.py"  \     # args of executable file
-    --input_path="test/input.txt" \     # where to get input
-    --output_path="test/output.txt" \   # where the output should be
-    --seccomp_rules=general \           # systemcall filte rules, optional `c_cpp`, `c_cpp_file_io`
-    --max_memory=33554432               # maximum memnory in bytes
+sudo ./sandbox \
+    --exe_path "/usr/bin/python3" \        # executable file path
+    --exe_args "test/test_py.py"  \        # arguments for the executable
+    --input_path "test/input.txt" \        # where to get input
+    --output_path "test/output.txt" \      # where the output should be
+    --seccomp_rules=general \              # systemcall filter rules, optional `c_cpp`, `c_cpp_file_io`
+    --max_memory=33554432                  # maximum memory in bytes
 ```
 
-Use `--help` to get more information about usages.
+Use `--help` to get a concise overview of all options.
 
-# Maintainers
+### Command-Line Options
+
+| Option | Description | Default |
+|-------|-------------|---------|
+| `--max_cpu_time <n>` | CPU time limit in milliseconds | unlimited |
+| `--max_real_time <n>` | Wall clock time limit in milliseconds | unlimited |
+| `--max_memory <str>` | Virtual memory limit in bytes | unlimited |
+| `--max_stack <str>` | Stack size limit in bytes | 16 MB |
+| `--max_process_number <n>` | Maximum number of processes | unlimited |
+| `--max_output_size <n>` | Maximum output file size in bytes | unlimited |
+| `--exe_path <str>` | **Required** path to the executable | – |
+| `--input_path <str>` | Input file path | `/dev/stdin` |
+| `--output_path <str>` | Output file path | `/dev/stdout` |
+| `--log_path <str>` | Log file path | `sandbox.log` |
+| `--exe_args <str>` | Arguments for the executable (repeatable) | none |
+| `--exe_envs <str>` | Environment variables (repeatable) | none |
+| `--seccomp_rules <str>` | Seccomp filter (`c_cpp`, `c_cpp_file_io`, `general`) | none |
+| `--uid <n>` | UID for running the executable (default `nobody`) | system nobody |
+| `--gid <n>` | GID for running the executable (default `nobody`) | system nobody |
+| `--help` | Show usage information | – |
+| `--version` | Show program version | – |
+
+After the program finishes, it outputs a JSON line describing the result and resource usage.
+
+## Maintainers
 
 [@jesHrz](https://github.com/jesHrz)
 
 [@Gene](https://github.com/GeneLiuXe)
 
-# Credits
+## Credits
 
-I would like to extend my sincere gratitude to those projects listed below for providing us solid technical support and creative inspiration.
+We thank the following projects for inspiration and technical support:
 
 - [QOJ-Judger](https://github.com/QingdaoU/Judger)
-
 - [How-it-works](https://docs.onlinejudge.me/#/judger/how_it_works)
 
-# License
+## License
 
 [SATA](https://github.com/SDUOJ/sduoj-sandbox/blob/master/LICENSE)
+

--- a/src/container/container.c
+++ b/src/container/container.c
@@ -128,7 +128,7 @@ void ChildProcess(FILE *log_fp, struct config *_config)
         // On error, -1 is returned, and errno is set appropriately.
         if (dup2(fileno(input_file), fileno(stdin)) == -1)
         {
-            // todo log
+            LOG_FATAL(log_fp, "dup2 stdin failed: %s", strerror(errno));
             CHILD_ERROR_EXIT(DUP2_FAILED);
         }
     }

--- a/src/util.c
+++ b/src/util.c
@@ -8,14 +8,23 @@
 
 void GetNobody(int *uid, int *gid)
 {
-    *uid = 65534;
-    *gid = 65534;
+    struct passwd *pwd = getpwnam("nobody");
+    if (pwd != NULL)
+    {
+        *uid = pwd->pw_uid;
+        *gid = pwd->pw_gid;
+    }
+    else
+    {
+        *uid = 65534;
+        *gid = 65534;
+    }
 }
 
-void Halt(int exit_coide)
+void Halt(int exit_code)
 {
     arg_freetable(arg_table, sizeof(arg_table) / sizeof(arg_table[0]));
-    exit(exit_coide);
+    exit(exit_code);
 }
 
 void UnexceptedArg()

--- a/src/util.h
+++ b/src/util.h
@@ -3,7 +3,7 @@
 
 #include "public.h"
 
-/* get uid and pid of role `nobody` */
+/* get uid and gid of user `nobody` */
 void GetNobody(int *uid, int *gid);
 
 /* release arg table and exit */


### PR DESCRIPTION
## Summary
- document installation and command line options in more detail
- look up `nobody` UID/GID using `getpwnam`
- fix typo in `Halt` parameter name
- log failure when duplicating stdin
- add missing newlines at EOF

## Testing
- `make` *(fails: seccomp.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684140ab9f0c832d9bde00b331b1fd43