### PR TITLE
Add --print_args flag and pass host env

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Use `--help` to get a concise overview of all options.
 | `--log_path <str>` | Log file path | `sandbox.log` |
 | `--exe_args <str>` | Arguments for the executable (repeatable) | none |
 | `--exe_envs <str>` | Environment variables (repeatable) | none |
+| `--print_args <n>` | Print parsed arguments when set to `1` | `0` |
 | `--seccomp_rules <str>` | Seccomp filter (`c_cpp`, `c_cpp_file_io`, `general`) | none |
 | `--uid <n>` | UID for running the executable (default `nobody`) | system nobody |
 | `--gid <n>` | GID for running the executable (default `nobody`) | system nobody |

--- a/src/parser.h
+++ b/src/parser.h
@@ -7,15 +7,16 @@
 #define INT_PLACEHOLDER "<n>"
 #define STR_PLACEHOLDER "<str>"
 
-#define NUM_ALLOWED_ARG 17
+#define NUM_ALLOWED_ARG 18
 
 extern struct arg_lit *help, *version;
 
-extern struct arg_int 
+extern struct arg_int
     *max_cpu_time,            /* maximum cpu time(ms) */
     *max_real_time,           /* maximum real time, include blocked time(ms) */
     *max_process_number,
     *max_output_size,
+    *print_args,
     *uid, *gid;               /* run sandbox in such uid and gid */
 
 extern struct arg_str 

--- a/src/public.h
+++ b/src/public.h
@@ -54,6 +54,8 @@ struct config {
     
     char *seccomp_rules;
 
+    int print_args;
+
     uid_t uid;
     gid_t gid;
 };


### PR DESCRIPTION
## Summary
- allow optional printing of configuration with `--print_args`
- inherit parent environment variables when `--exe_envs` is unspecified
- document new option

## Testing
- `make` *(fails: seccomp headers not present)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce26997c832d8fd790366df7be1b