### PR TITLE
Add set_tid_address syscall to whitelist

### DIFF
--- a/src/rules/c_cpp.c
+++ b/src/rules/c_cpp.c
@@ -17,7 +17,8 @@ int _c_cpp_seccomp_rules(struct config *_config, int allow_write_file)
                                 SCMP_SYS(close), SCMP_SYS(readlink),
                                 SCMP_SYS(sysinfo), SCMP_SYS(write),
                                 SCMP_SYS(writev), SCMP_SYS(lseek),
-                                SCMP_SYS(clock_gettime)};
+                                SCMP_SYS(clock_gettime),
+                                SCMP_SYS(set_tid_address)};
 
     int syscalls_whitelist_length = sizeof(syscalls_whitelist) / sizeof(int);
     scmp_filter_ctx ctx = NULL;


### PR DESCRIPTION
## Summary
- allow `set_tid_address` syscall in c/c++ seccomp whitelist

## Testing
- `make` *(fails: seccomp.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845e20fe430832d8be83d08655ce7bf