### PR TITLE
Fix log file double-close and build on x86-64

### DIFF
--- a/src/container/container.c
+++ b/src/container/container.c
@@ -16,6 +16,7 @@
 #include <pthread.h>
 #include <sys/ptrace.h>
 #include <sys/user.h>
+#include <sys/reg.h>
 
 #include <sys/wait.h>
 #include <sys/time.h>
@@ -368,6 +369,9 @@ void Run(struct config *_config, struct result *_result)
         }
 
         MonitorUsage(log_fp, child_pid, _config, _result, &resource_usage, &status);
-        GenerateResult(log_fp, _config, _result, &resource_usage, &status, &start, &end);
+        if (_result->error == SUCCESS)
+        {
+            GenerateResult(log_fp, _config, _result, &resource_usage, &status, &start, &end);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- include `<sys/reg.h>` so ORIG_RAX is defined
- avoid closing log file twice when `MonitorUsage` fails

## Testing
- `make`
- `./build/bin/sandbox --exe_path test/test_c --seccomp_rules=general --max_memory=268435456 --max_cpu_time=5000 --max_output_size=209715200 --output_path test/out_c.txt`


------
https://chatgpt.com/codex/tasks/task_e_68468c6b7020832d8b1ed9ba79b56f65